### PR TITLE
Lägg till Vårdbetyg som case

### DIFF
--- a/_cases/vardbetyg.md
+++ b/_cases/vardbetyg.md
@@ -1,0 +1,8 @@
+---
+title: Vårdbetyg
+region: sweden
+status: active
+link: https://vardbetyg.se
+year: 2026
+---
+Vårdbetyg väger samman Nationell Patientenkät och Socialstyrelsens väntetider till ett sammanvägt betyg per vårdcentral, med bayesiansk krympning efter antal svar och öppna konfidensintervall. Det härledda datasetet publiceras öppet under CC BY 4.0. En oberoende tjänst byggd helt på öppna offentliga källor.


### PR DESCRIPTION
Lägger till `_cases/vardbetyg.md` enligt förslaget i #27.

Vårdbetyg (https://vardbetyg.se) är en oberoende tjänst som väger samman Nationell Patientenkät och Socialstyrelsens väntetidsstatistik till ett jämförbart betyg per vårdcentral, med bayesiansk krympning efter antal svar och öppna konfidensintervall. Det härledda datasetet publiceras öppet under CC BY 4.0 (och som DCAT-AP-SE för dataportal.se).

Full transparens: jag är grundare av tjänsten.

Filen följer samma front matter- och textformat som övriga case i `_cases/`. Säg till om ni vill justera formulering, `year` eller `status`.

Closes #27